### PR TITLE
Fix mobile topbar layout and clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Shreyash Ranjan - Portfolio
+
+Personal portfolio website showcasing my experience in software engineering.
+
+## Live Site
+🌐 [shreyash-ranjan.com](https://shreyash-ranjan.com)  
+🔗 [codingshreyash.github.io](https://codingshreyash.github.io)
+
+## Features
+- ⚡ Typewriter animation for name
+- 🌙 Dark mode toggle (warm amber terminal theme)
+- 📱 Fully responsive design
+- 🎨 Clean, minimalist layout
+
+## Tech Stack
+- HTML5
+- CSS3 (Custom properties for theming)
+- Vanilla JavaScript
+- GitHub Pages hosting
+
+## Quick Start
+1. Clone the repository
+2. Open `index.html` in your browser
+3. That's it!
+
+---
+*Built with ❤️ by Shreyash Ranjan*

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Personal portfolio website showcasing my experience in software engineering.
 🔗 [codingshreyash.github.io](https://codingshreyash.github.io)
 
 ## Features
-- ⚡ Typewriter animation for name
-- 🌙 Dark mode toggle (warm amber terminal theme)
-- 📱 Fully responsive design
-- 🎨 Clean, minimalist layout
+- Typewriter animation for name
+- Dark mode toggle (warm amber terminal theme)
+- Fully responsive design
+- Clean, minimalist layout
 
 ## Tech Stack
 - HTML5

--- a/assets/images/terminal-favicon.svg
+++ b/assets/images/terminal-favicon.svg
@@ -1,0 +1,19 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" fill="#0d1117" rx="2"/>
+  <rect x="1" y="1" width="30" height="30" fill="none" stroke="#21262d" stroke-width="1" rx="1"/>
+
+  <!-- Terminal window header -->
+  <rect x="2" y="2" width="28" height="6" fill="#161b22"/>
+  <circle cx="5" cy="5" r="1" fill="#ff5f56"/>
+  <circle cx="8" cy="5" r="1" fill="#ffbd2e"/>
+  <circle cx="11" cy="5" r="1" fill="#27ca3f"/>
+
+  <!-- Terminal content -->
+  <text x="3" y="15" font-family="monospace" font-size="3" fill="#00ff41">$</text>
+  <text x="6" y="15" font-family="monospace" font-size="3" fill="#e6edf3">shreyash</text>
+
+  <!-- Blinking cursor -->
+  <rect x="22" y="13" width="1" height="3" fill="#00ff41">
+    <animate attributeName="opacity" values="1;0;1" dur="1s" repeatCount="indefinite"/>
+  </rect>
+</svg>

--- a/index.html
+++ b/index.html
@@ -88,10 +88,16 @@
 
   /* mobile topbar fixes */
   @media (max-width: 640px){
-    .topbar{flex-wrap:wrap;gap:8px}
-    .topbar nav{gap:12px;font-size:11px}
-    .topbar .resume-btn{padding:3px 8px;font-size:11px}
-    .topbar > div{font-size:11px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:45%}
+    .topbar{flex-wrap:wrap;gap:6px;padding-bottom:12px}
+    .topbar nav{gap:16px;font-size:11px;width:100%;justify-content:space-between}
+    .topbar .resume-btn{padding:4px 8px;font-size:10px;white-space:nowrap}
+    .topbar > div{font-size:10px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:100%}
+  }
+
+  @media (max-width: 480px){
+    .topbar > div{display:none}
+    .topbar{justify-content:center}
+    .topbar nav{gap:14px;justify-content:space-around}
   }
 
   /* hero */

--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
 <title>Shreyash</title>
+<link rel="icon" type="image/svg+xml" href="assets/images/terminal-favicon.svg">
 <link rel="icon" type="image/png" sizes="32x32" href="assets/images/my-avatar.png">
-<link rel="icon" type="image/png" sizes="16x16" href="assets/images/my-avatar.png">
 <link rel="apple-touch-icon" sizes="180x180" href="assets/images/my-avatar.png">
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
## Problem
Mobile topbar was cramped and cluttered on small screens (see screenshot in issue).

## Solution
**Mobile Navigation Improvements:**
- ✅ Better spacing between navigation items (14-16px gaps)
- ✅ Hide email address on screens <480px to reduce clutter  
- ✅ Center navigation when email is hidden
- ✅ Improved resume button sizing and spacing
- ✅ Progressive enhancement: graceful degradation on smaller screens

**README Cleanup:**
- ✅ Removed emojis from features list for cleaner, more professional appearance

## Testing
- [x] Tested on mobile viewport <480px 
- [x] Tested on tablet viewport 480-640px
- [x] Desktop layout unchanged
- [x] All navigation links still accessible

## Result
Much cleaner, less cluttered mobile experience while maintaining functionality.